### PR TITLE
Add Nostr relay integration and profile updates

### DIFF
--- a/hooks/useAgentMemory.ts
+++ b/hooks/useAgentMemory.ts
@@ -1,0 +1,142 @@
+import { useState, useCallback, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNostrStore } from '../lib/nostr/store';
+import { AgentProfile, AgentTask, createProfileEvent, createTaskEvent } from '../lib/nostr/events';
+
+const STORAGE_KEYS = {
+  PROFILE: '@cozy_profile',
+  TASKS: '@cozy_tasks'
+};
+
+export const useAgentMemory = () => {
+  const { keys, relay } = useNostrStore();
+  const [profile, setProfile] = useState<AgentProfile | null>(null);
+  const [tasks, setTasks] = useState<AgentTask[]>([]);
+
+  // Load cached data and subscribe to updates
+  useEffect(() => {
+    if (!keys?.publicKey || !relay) return;
+
+    const loadData = async () => {
+      try {
+        // Load cached data
+        const [cachedProfile, cachedTasks] = await Promise.all([
+          AsyncStorage.getItem(STORAGE_KEYS.PROFILE),
+          AsyncStorage.getItem(STORAGE_KEYS.TASKS)
+        ]);
+
+        if (cachedProfile) setProfile(JSON.parse(cachedProfile));
+        if (cachedTasks) setTasks(JSON.parse(cachedTasks));
+
+        // Subscribe to profile updates
+        await relay.subscribeToProfile(keys.publicKey, (event) => {
+          const newProfile = JSON.parse(event.content);
+          setProfile(newProfile);
+          AsyncStorage.setItem(STORAGE_KEYS.PROFILE, JSON.stringify(newProfile));
+        });
+
+        // Subscribe to task updates
+        await relay.subscribeToTasks(keys.publicKey, (event) => {
+          const task = JSON.parse(event.content);
+          setTasks(prev => {
+            const newTasks = prev.filter(t => t.id !== task.id);
+            return [...newTasks, task].sort((a, b) => 
+              new Date(b.date).getTime() - new Date(a.date).getTime()
+            );
+          });
+        });
+      } catch (error) {
+        console.error('Error loading agent data:', error);
+      }
+    };
+
+    loadData();
+
+    // Cleanup subscriptions
+    return () => {
+      if (relay) {
+        relay.closeSubscription(`profile:${keys.publicKey}`);
+        relay.closeSubscription(`tasks:${keys.publicKey}`);
+      }
+    };
+  }, [keys?.publicKey, relay]);
+
+  const updateProfile = useCallback(async (updates: Partial<AgentProfile>) => {
+    if (!keys || !relay) return;
+
+    try {
+      const newProfile = { ...profile, ...updates } as AgentProfile;
+      const event = await createProfileEvent(newProfile);
+      
+      // Publish to relay
+      const published = await relay.publish(event);
+      if (!published) throw new Error('Failed to publish profile update');
+      
+      setProfile(newProfile);
+      await AsyncStorage.setItem(STORAGE_KEYS.PROFILE, JSON.stringify(newProfile));
+    } catch (error) {
+      console.error('Error updating profile:', error);
+      throw error;
+    }
+  }, [profile, keys, relay]);
+
+  const createTask = useCallback(async (task: Omit<AgentTask, 'id'>) => {
+    if (!keys || !relay) return;
+
+    try {
+      const newTask = {
+        ...task,
+        id: crypto.randomUUID()
+      };
+
+      const event = await createTaskEvent(newTask);
+      
+      // Publish to relay
+      const published = await relay.publish(event);
+      if (!published) throw new Error('Failed to publish task');
+      
+      setTasks(prev => [...prev, newTask]);
+      await AsyncStorage.setItem(STORAGE_KEYS.TASKS, JSON.stringify([...tasks, newTask]));
+      
+      return newTask;
+    } catch (error) {
+      console.error('Error creating task:', error);
+      throw error;
+    }
+  }, [tasks, keys, relay]);
+
+  const updateTask = useCallback(async (taskId: string, updates: Partial<AgentTask>) => {
+    if (!keys || !relay) return;
+
+    try {
+      const taskIndex = tasks.findIndex(t => t.id === taskId);
+      if (taskIndex === -1) throw new Error('Task not found');
+
+      const updatedTask = { ...tasks[taskIndex], ...updates };
+      const event = await createTaskEvent(updatedTask);
+      
+      // Publish to relay
+      const published = await relay.publish(event);
+      if (!published) throw new Error('Failed to publish task update');
+      
+      const newTasks = [...tasks];
+      newTasks[taskIndex] = updatedTask;
+      
+      setTasks(newTasks);
+      await AsyncStorage.setItem(STORAGE_KEYS.TASKS, JSON.stringify(newTasks));
+      
+      return updatedTask;
+    } catch (error) {
+      console.error('Error updating task:', error);
+      throw error;
+    }
+  }, [tasks, keys, relay]);
+
+  return {
+    profile,
+    tasks,
+    updateProfile,
+    createTask,
+    updateTask
+  };
+};

--- a/lib/nostr/events.ts
+++ b/lib/nostr/events.ts
@@ -1,0 +1,84 @@
+import { getEventHash, signEvent, Event } from 'nostr-tools';
+import { useNostrStore } from './store';
+
+export interface AgentProfile {
+  name: string;
+  color: string;
+  health: number;
+}
+
+export interface AgentTask {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  date: string;
+}
+
+export interface NostrMetadata {
+  name?: string;
+  about?: string;
+  picture?: string;
+  [key: string]: any; // For additional fields
+}
+
+export const COZY_PREFIXES = {
+  AGENT_PROFILE: 'cozy:agent:profile',
+  TASK: 'cozy:agent:task'
+};
+
+// Create kind 0 metadata event (NIP-01)
+export const createMetadataEvent = async (metadata: NostrMetadata): Promise<Event> => {
+  const { keys } = useNostrStore.getState();
+  if (!keys?.privateKey) throw new Error('No private key available');
+
+  const event = {
+    kind: 0,
+    pubkey: keys.publicKey,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [],
+    content: JSON.stringify(metadata)
+  } as Event;
+
+  event.id = getEventHash(event);
+  event.sig = signEvent(event, keys.privateKey);
+
+  return event;
+};
+
+// Create kind 30078 profile event (Cozy-specific)
+export const createProfileEvent = async (profile: AgentProfile): Promise<Event> => {
+  const { keys } = useNostrStore.getState();
+  if (!keys?.privateKey) throw new Error('No private key available');
+
+  const event = {
+    kind: 30078,
+    pubkey: keys.publicKey,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['d', COZY_PREFIXES.AGENT_PROFILE]],
+    content: JSON.stringify(profile)
+  } as Event;
+
+  event.id = getEventHash(event);
+  event.sig = signEvent(event, keys.privateKey);
+
+  return event;
+};
+
+export const createTaskEvent = async (task: AgentTask): Promise<Event> => {
+  const { keys } = useNostrStore.getState();
+  if (!keys?.privateKey) throw new Error('No private key available');
+
+  const event = {
+    kind: 30080,
+    pubkey: keys.publicKey,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['d', `${COZY_PREFIXES.TASK}:${task.id}`]],
+    content: JSON.stringify(task)
+  } as Event;
+
+  event.id = getEventHash(event);
+  event.sig = signEvent(event, keys.privateKey);
+
+  return event;
+};

--- a/lib/nostr/relay.ts
+++ b/lib/nostr/relay.ts
@@ -1,0 +1,113 @@
+import { Relay } from 'nostr-tools/relay'
+import { Event } from 'nostr-tools/pure'
+
+export class NostrRelay {
+  private relay: Relay | null = null
+  private subscriptions: Map<string, any> = new Map()
+  private connected: boolean = false
+
+  async connect() {
+    try {
+      this.relay = await Relay.connect('wss://nostr-pub.wellorder.net')
+      this.connected = true
+      console.log('Connected to relay:', this.relay.url)
+    } catch (error) {
+      console.error('Failed to connect to relay:', error)
+      this.connected = false
+    }
+  }
+
+  async ensureConnection() {
+    if (!this.connected || !this.relay) {
+      await this.connect()
+    }
+    if (!this.relay) throw new Error('Failed to connect to relay')
+  }
+
+  // Subscribe to profile events (kind 30078 - replaceable)
+  async subscribeToProfile(pubkey: string, onEvent: (event: Event) => void) {
+    await this.ensureConnection()
+    
+    const sub = this.relay!.subscribe([
+      {
+        kinds: [30078],
+        authors: [pubkey],
+        limit: 1
+      }
+    ], {
+      onevent(event: Event) {
+        try {
+          onEvent(event)
+        } catch (error) {
+          console.error('Error handling profile event:', error)
+        }
+      },
+      oneose() {
+        console.log('End of stored profile events')
+      }
+    })
+
+    this.subscriptions.set(`profile:${pubkey}`, sub)
+    return sub
+  }
+
+  // Subscribe to task events (kind 30080 - addressable)
+  async subscribeToTasks(pubkey: string, onEvent: (event: Event) => void) {
+    await this.ensureConnection()
+    
+    const sub = this.relay!.subscribe([
+      {
+        kinds: [30080],
+        authors: [pubkey],
+        since: Math.floor(Date.now() / 1000) - 86400 * 7 // Last 7 days
+      }
+    ], {
+      onevent(event: Event) {
+        try {
+          onEvent(event)
+        } catch (error) {
+          console.error('Error handling task event:', error)
+        }
+      },
+      oneose() {
+        console.log('End of stored task events')
+      }
+    })
+
+    this.subscriptions.set(`tasks:${pubkey}`, sub)
+    return sub
+  }
+
+  // Publish an event
+  async publish(event: Event): Promise<boolean> {
+    await this.ensureConnection()
+    
+    try {
+      const pub = await this.relay!.publish(event)
+      return true
+    } catch (error) {
+      console.error('Failed to publish event:', error)
+      return false
+    }
+  }
+
+  // Close specific subscription
+  closeSubscription(id: string) {
+    const sub = this.subscriptions.get(id)
+    if (sub) {
+      sub.close()
+      this.subscriptions.delete(id)
+    }
+  }
+
+  // Cleanup all subscriptions and close connection
+  cleanup() {
+    this.subscriptions.forEach(sub => sub.close())
+    this.subscriptions.clear()
+    if (this.relay) {
+      this.relay.close()
+      this.relay = null
+    }
+    this.connected = false
+  }
+}

--- a/lib/nostr/relay.ts
+++ b/lib/nostr/relay.ts
@@ -1,113 +1,125 @@
-import { Relay } from 'nostr-tools/relay'
-import { Event } from 'nostr-tools/pure'
+import { relayInit, Event } from 'nostr-tools';
 
 export class NostrRelay {
-  private relay: Relay | null = null
-  private subscriptions: Map<string, any> = new Map()
-  private connected: boolean = false
+  private relay: any = null;
+  private subscriptions: Map<string, any> = new Map();
+  private connected: boolean = false;
 
   async connect() {
     try {
-      this.relay = await Relay.connect('wss://nostr-pub.wellorder.net')
-      this.connected = true
-      console.log('Connected to relay:', this.relay.url)
+      this.relay = relayInit('wss://nostr-pub.wellorder.net');
+      await this.relay.connect();
+      
+      this.relay.on('connect', () => {
+        console.log('Connected to relay');
+        this.connected = true;
+      });
+      
+      this.relay.on('error', () => {
+        console.log('Failed to connect to relay');
+        this.connected = false;
+      });
+
+      console.log('Connected to relay:', this.relay.url);
     } catch (error) {
-      console.error('Failed to connect to relay:', error)
-      this.connected = false
+      console.error('Failed to connect to relay:', error);
+      this.connected = false;
     }
   }
 
   async ensureConnection() {
     if (!this.connected || !this.relay) {
-      await this.connect()
+      await this.connect();
     }
-    if (!this.relay) throw new Error('Failed to connect to relay')
+    if (!this.relay) throw new Error('Failed to connect to relay');
   }
 
   // Subscribe to profile events (kind 30078 - replaceable)
   async subscribeToProfile(pubkey: string, onEvent: (event: Event) => void) {
-    await this.ensureConnection()
+    await this.ensureConnection();
     
-    const sub = this.relay!.subscribe([
+    const sub = this.relay.sub([
       {
         kinds: [30078],
         authors: [pubkey],
         limit: 1
       }
-    ], {
-      onevent(event: Event) {
-        try {
-          onEvent(event)
-        } catch (error) {
-          console.error('Error handling profile event:', error)
-        }
-      },
-      oneose() {
-        console.log('End of stored profile events')
-      }
-    })
+    ]);
 
-    this.subscriptions.set(`profile:${pubkey}`, sub)
-    return sub
+    sub.on('event', (event: Event) => {
+      try {
+        onEvent(event);
+      } catch (error) {
+        console.error('Error handling profile event:', error);
+      }
+    });
+
+    sub.on('eose', () => {
+      console.log('End of stored profile events');
+    });
+
+    this.subscriptions.set(`profile:${pubkey}`, sub);
+    return sub;
   }
 
   // Subscribe to task events (kind 30080 - addressable)
   async subscribeToTasks(pubkey: string, onEvent: (event: Event) => void) {
-    await this.ensureConnection()
+    await this.ensureConnection();
     
-    const sub = this.relay!.subscribe([
+    const sub = this.relay.sub([
       {
         kinds: [30080],
         authors: [pubkey],
         since: Math.floor(Date.now() / 1000) - 86400 * 7 // Last 7 days
       }
-    ], {
-      onevent(event: Event) {
-        try {
-          onEvent(event)
-        } catch (error) {
-          console.error('Error handling task event:', error)
-        }
-      },
-      oneose() {
-        console.log('End of stored task events')
-      }
-    })
+    ]);
 
-    this.subscriptions.set(`tasks:${pubkey}`, sub)
-    return sub
+    sub.on('event', (event: Event) => {
+      try {
+        onEvent(event);
+      } catch (error) {
+        console.error('Error handling task event:', error);
+      }
+    });
+
+    sub.on('eose', () => {
+      console.log('End of stored task events');
+    });
+
+    this.subscriptions.set(`tasks:${pubkey}`, sub);
+    return sub;
   }
 
   // Publish an event
   async publish(event: Event): Promise<boolean> {
-    await this.ensureConnection()
+    await this.ensureConnection();
     
     try {
-      const pub = await this.relay!.publish(event)
-      return true
+      const pub = await this.relay.publish(event);
+      return true;
     } catch (error) {
-      console.error('Failed to publish event:', error)
-      return false
+      console.error('Failed to publish event:', error);
+      return false;
     }
   }
 
   // Close specific subscription
   closeSubscription(id: string) {
-    const sub = this.subscriptions.get(id)
+    const sub = this.subscriptions.get(id);
     if (sub) {
-      sub.close()
-      this.subscriptions.delete(id)
+      sub.unsub();
+      this.subscriptions.delete(id);
     }
   }
 
   // Cleanup all subscriptions and close connection
   cleanup() {
-    this.subscriptions.forEach(sub => sub.close())
-    this.subscriptions.clear()
+    this.subscriptions.forEach(sub => sub.unsub());
+    this.subscriptions.clear();
     if (this.relay) {
-      this.relay.close()
-      this.relay = null
+      this.relay.close();
+      this.relay = null;
     }
-    this.connected = false
+    this.connected = false;
   }
 }


### PR DESCRIPTION
This PR adds Nostr relay integration and profile updates:

### Changes
1. Added NostrRelay class for relay management:
   - WebSocket connection to `wss://nostr-pub.wellorder.net`
   - Event subscription handling
   - Event publishing
   - Proper cleanup

2. Added event types and creation:
   - NIP-01 metadata events (kind 0)
   - Cozy profile events (kind 30078)
   - Task events (kind 30080)

3. Updated welcome screen:
   - Profile updates on login/account creation
   - Both NIP-01 and Cozy-specific events
   - Error handling and fallbacks

### Testing
1. Create new account:
   - Should connect to relay
   - Should create metadata event
   - Should create profile event

2. Login with existing account:
   - Should connect to relay
   - Should update profile if changed

3. Error cases:
   - Handles relay connection failures
   - Allows continuing if profile update fails
   - Proper error messages

### Related Issues
Closes #27 - Add Nostr relay integration

### Notes
- Using older nostr-tools syntax for compatibility
- Added both standard (kind 0) and custom (kind 30078) events
- Proper cleanup on logout/unmount